### PR TITLE
Don't reexecute sender_wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Then you need to include your zabbix conf folder in `zabbix_agentd.conf`, like t
 ```conf
 Include=/usr/local/etc/zabbix/zabbix_agentd.conf.d/
 ```
-Also its recomended to add at least `Timeout=10` to config file to allow drives spun up in rare cases.
 
 That's all for Windows. For others run the following to finish configuration:
 ```bash

--- a/scripts/smartctl-lld.py
+++ b/scripts/smartctl-lld.py
@@ -33,4 +33,4 @@ if __name__ == '__main__':
         senderData.append('%s smartctl.info[ConfigStatus] "CONFIGURED"' % (host))   # signals that client host is configured (also fallback)
 
     link = r'https://github.com/nobodysu/zabbix-smartmontools/issues'
-    processData(senderData, jsonData, config['agentConf'], config['senderPyPath'], config['senderPath'], config['timeout'], host, link)
+    processData(senderData, jsonData, config['agentConf'], config['senderPyPath'], config['senderPath'], host, link)

--- a/smartctl_lld/__init__.py
+++ b/smartctl_lld/__init__.py
@@ -395,7 +395,6 @@ def parseConfig(path=None):
         'senderPyPath': config.get('settings', 'senderPyPath',
             fallback=sender_py_path),
         'agentConf': config.get('settings', 'agentConf', fallback=agent_conf),
-        'timeout': config.getint('settings', 'timeout', fallback=80)
     }
     if config.has_section('Disks'):
         d['Disks'] = ["%s %s" % (k, v) for (k, v) in config['Disks'].items()]

--- a/smartctl_lld/sender_wrapper.py
+++ b/smartctl_lld/sender_wrapper.py
@@ -147,15 +147,6 @@ def clearDiskTypeStr(s):
     return s
 
 
-def removeQuotes(s):
-    quotes = ('\'', '"')
-
-    for i in quotes:
-        s = s.replace(i, '')
-
-    return s
-
-
 def sanitizeStr(s):
     '''Sanitizes provided string in sequential order.'''
     stopChars = (

--- a/test/example/no_disk_list.conf
+++ b/test/example/no_disk_list.conf
@@ -5,4 +5,3 @@ ctlPath: smartctl
 senderPyPath: /etc/zabbix/scripts/sender_wrapper.py
 agentConf: /etc/zabbix/zabbix_agentd.conf
 senderPath: zabbix_sender
-timeout: 80

--- a/test/example/with_disk_list.conf
+++ b/test/example/with_disk_list.conf
@@ -5,7 +5,6 @@ ctlPath: smartctl
 senderPyPath: /etc/zabbix/scripts/sender_wrapper.py
 agentConf: /etc/zabbix/zabbix_agentd.conf
 senderPath: zabbix_sender
-timeout: 80
 
 [Disks]
 /dev/sda: -d sat+megaraid,4

--- a/test/test_smartctl_lld.py
+++ b/test/test_smartctl_lld.py
@@ -27,7 +27,7 @@ class TestGetAllDisks(unittest.TestCase):
         da0_output = f.read()
         f.close()
         patchCheckOutput.side_effect = mock_smartctl({'-a /dev/da0 -d auto': da0_output})
-        config = smartctl_lld.parseConfig(None)
+        config = smartctl_lld.parseConfig("test/example/empty")
         r = smartctl_lld.getAllDisks(config, "myhost", "getverb", ["/dev/da0 -d scsi"])
         self.assertEqual(r,
             ([{'{#DDRIVESTATUS}': 'da0'}, {'{#DISKID}': 'da0'}, {'{#DISKIDSAS}': 'da0'}],
@@ -61,7 +61,7 @@ class TestGetAllDisks(unittest.TestCase):
             '-a /dev/da0 -d auto': da0_output,
             '-a /dev/da1 -d auto': da1_output,
         })
-        config = smartctl_lld.parseConfig(None)
+        config = smartctl_lld.parseConfig("test/example/empty")
         config['skipDuplicates'] = True
         r = smartctl_lld.getAllDisks(config, "myhost", "getverb", [
             "/dev/da0 -d scsi",
@@ -99,7 +99,7 @@ class TestGetAllDisks(unittest.TestCase):
         da0_output = f.read()
         f.close()
         patchCheckOutput.side_effect = mock_smartctl({'-a /dev/da0 -d auto': da0_output})
-        config = smartctl_lld.parseConfig(None)
+        config = smartctl_lld.parseConfig("test/example/empty")
         config['mode'] = 'serial'
         r = smartctl_lld.getAllDisks(config, "myhost", "getverb", ["/dev/da0 -d scsi"])
         self.assertEqual(r,
@@ -133,7 +133,7 @@ class TestGetSmart(unittest.TestCase):
         output = f.read()
         f.close()
         patchCheckOutput.side_effect = mock_smartctl({'-a /dev/da0 -d auto': output})
-        config = smartctl_lld.parseConfig(None)
+        config = smartctl_lld.parseConfig("test/example/empty")
         r = smartctl_lld.getSmart(config, "myhost", "getverb", "/dev/da0 -d scsi ")
         self.assertEqual(r, expected)
 
@@ -200,7 +200,7 @@ class TestParseConfig(unittest.TestCase):
 class TestScan(unittest.TestCase):
     def runtest(self, output, expected_disks, patchCheckOutput):
         patchCheckOutput.side_effect = mock_smartctl({'--scan': output})
-        config = smartctl_lld.parseConfig(None)
+        config = smartctl_lld.parseConfig("test/example/empty")
         (error, disks) = smartctl_lld.scanDisks(config, "getverb")
         self.assertEqual(error, "")
         self.assertEqual(disks, expected_disks)

--- a/test/test_smartctl_lld.py
+++ b/test/test_smartctl_lld.py
@@ -175,7 +175,6 @@ class TestParseConfig(unittest.TestCase):
         self.assertEqual(config['mode'], 'device')
         self.assertTrue(config['skipDuplicates'])
         self.assertEqual(config['ctlPath'], 'smartctl')
-        self.assertEqual(config['timeout'], 80)
         self.assertFalse('Disks' in config)
 
     def test_disk_list(self):
@@ -194,7 +193,6 @@ class TestParseConfig(unittest.TestCase):
                 '/etc/zabbix/scripts/sender_wrapper.py')
         self.assertEqual(config['agentConf'], '/etc/zabbix/zabbix_agentd.conf')
         self.assertEqual(config['senderPath'], 'zabbix_sender')
-        self.assertEqual(config['timeout'], 80)
         self.assertFalse('Disks' in config)
 
 class TestScan(unittest.TestCase):

--- a/zabbix-smartmontools.conf
+++ b/zabbix-smartmontools.conf
@@ -36,11 +36,6 @@
 # Windows:
 # senderPath: C:\zabbix-agent\bin\win32\zabbix_sender.exe
 
-# how long the script must wait between LLD and sending, increase if data
-# received late (does not affect windows).
-# this setting MUST be lower than 'Update interval' in discovery rule
-# timeout: 80
-
 # manually provide disk list or RAID configuration if needed
 # more info: https://www.smartmontools.org/wiki/Supported_RAID-Controllers
 # [Disks]


### PR DESCRIPTION
It's unnecessarily slow, and it fails with a large number of disks because it exceeds the system's maximum command line length.